### PR TITLE
[WIP] Set invite mail from header to sender

### DIFF
--- a/useradmin/app/controllers/application_controller.rb
+++ b/useradmin/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
       request.set_header('REMOTE_USER', 'isaac@university-example.org')
       request.set_header('Shib-uid', 'isaac')
       request.set_header('Shib-commonName', 'Sir Isaac Newton')
+      request.set_header('Shib-email', 'isaacnewton@university-example.org;newton@university-example.org')
       request.set_header('Shib-homeOrganization', 'university-example.org')
       request.set_header('Shib-eduPersonEntitlement', 'urn:x-surfnet:surfsara.nl:opennebula:admin')
       request.set_header('Shib-eduPersonPrincipalName', 'isaac@university-example.org')

--- a/useradmin/app/lib/current_user.rb
+++ b/useradmin/app/lib/current_user.rb
@@ -19,6 +19,10 @@ CurrentUser = Struct.new(:request) do
     request.get_header('Shib-eduPersonEntitlement')
   end
 
+  def email
+    request.get_header('Shib-email')
+  end
+
   def shibboleth_headers
     Hash[request.headers.select { |k, _| k.starts_with?('Shib-') }]
   end
@@ -42,6 +46,10 @@ CurrentUser = Struct.new(:request) do
   def role
     return Role.surfsara_admin if surfsara_admin?
     return Role.group_admin if group_admin?
+  end
+
+  def primary_email_address
+    (email || '').split(';').first
   end
 
   def surfsara_admin?

--- a/useradmin/app/mailers/invite_mailer.rb
+++ b/useradmin/app/mailers/invite_mailer.rb
@@ -1,7 +1,7 @@
 class InviteMailer < ApplicationMailer
-  def invitation(model, token)
+  def invitation(model, raw_token, sender)
     @model = model
-    @token = token
-    mail(to: @model.email)
+    @token = raw_token
+    mail from: sender, to: @model.email
   end
 end

--- a/useradmin/app/operations/invite/create.rb
+++ b/useradmin/app/operations/invite/create.rb
@@ -39,7 +39,12 @@ class Invite < ApplicationRecord
     end
 
     def send_invitation!
-      InviteMailer.invitation(@model, invite_token.raw).deliver_now
+      InviteMailer.invitation(@model, invite_token.raw, sender).deliver_now
+    end
+
+    def sender
+      return nil if current_user.primary_email_address.blank?
+      "#{current_user.common_name} <#{current_user.primary_email_address}>"
     end
 
     def invite_token

--- a/useradmin/spec/factories/current_user.rb
+++ b/useradmin/spec/factories/current_user.rb
@@ -4,5 +4,8 @@ FactoryGirl.define do
     one_username 'isaac@university-example.org'
     one_password '3d21c8a6d89e3332e3d388852f99d5e5ce114ff9'
     admin_groups { build_list(:one_group, 1) }
+    common_name 'Sir Isaac Newton'
+    email 'isaacnewton@university-example.org;newton@university-example.org'
+    primary_email_address 'isaacnewton@university-example.org'
   end
 end

--- a/useradmin/spec/mailers/invite_mailer_spec.rb
+++ b/useradmin/spec/mailers/invite_mailer_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe InviteMailer, type: :mailer do
       ).model
     end
     let(:token) { '123abc' }
-    let(:mail) { InviteMailer.invitation(invite, token).deliver_now }
+    let(:sender) { 'Bob Forma <bforma@zilverline.com>' }
+    let(:mail) { InviteMailer.invitation(invite, token, sender).deliver_now }
 
     it 'renders the subject' do
       expect(mail.subject).to eq('Invitation')
@@ -20,7 +21,7 @@ RSpec.describe InviteMailer, type: :mailer do
     end
 
     it 'renders the sender email' do
-      expect(mail.from).to eq(['useradmin@surfsara.nl'])
+      expect(mail['From'].to_s).to eq(sender)
     end
 
     it 'contains the activation link' do


### PR DESCRIPTION
WARNING: Not sure if we should merge this, since we can't just send mail in behalf of a random user..

Use the primary email address from the Shibboleth mail header.